### PR TITLE
Adds support to display Scala version in report

### DIFF
--- a/src/main/scala/org/scalaide/buildtools/Ecosystem.scala
+++ b/src/main/scala/org/scalaide/buildtools/Ecosystem.scala
@@ -109,11 +109,11 @@ object Ecosystem {
     }
   }
 
-  abstract class EclipseVersion(val name: String, val repoLocation: String)
+  abstract class EclipseVersion(val id: String, val name: String, val repoLocation: String)
 
-  case object EclipseIndigo extends EclipseVersion("indigo", "http://download.eclipse.org/releases/indigo/")
+  case object EclipseIndigo extends EclipseVersion("indigo", "Indigo", "http://download.eclipse.org/releases/indigo/")
 
-  case object EclipseJuno extends EclipseVersion("juno", "http://download.eclipse.org/releases/juno/")
+  case object EclipseJuno extends EclipseVersion("juno", "Juno", "http://download.eclipse.org/releases/juno/")
 
   def findStrictVersion(range: String) = {
     range match {

--- a/src/main/scala/org/scalaide/buildtools/EcosystemBuildsMavenProjects.scala
+++ b/src/main/scala/org/scalaide/buildtools/EcosystemBuildsMavenProjects.scala
@@ -293,7 +293,7 @@ object EcosystemBuildsMavenProjects {
       </properties>
       <repositories>
         <repository>
-          <id>eclipse.{ scalaIDEVersion.eclipseVersion.name }</id>
+          <id>eclipse.{ scalaIDEVersion.eclipseVersion.id }</id>
           <name>Eclipse p2 repository</name>
           <layout>p2</layout>
           <url>{ scalaIDEVersion.eclipseVersion.repoLocation }</url>
@@ -359,7 +359,7 @@ object EcosystemBuildsMavenProjects {
       </properties>
       <repositories>
         <repository>
-          <id>eclipse.{ scalaIDEVersion.eclipseVersion.name }</id>
+          <id>eclipse.{ scalaIDEVersion.eclipseVersion.id }</id>
           <name>Eclipse p2 repository</name>
           <layout>p2</layout>
           <url>{ scalaIDEVersion.eclipseVersion.repoLocation }</url>

--- a/src/main/scala/org/scalaide/buildtools/EcosystemBuildsReport.scala
+++ b/src/main/scala/org/scalaide/buildtools/EcosystemBuildsReport.scala
@@ -4,6 +4,7 @@ import java.io.File
 import scala.xml.Elem
 import java.util.Date
 import java.text.SimpleDateFormat
+import Ecosystem._
 
 object EcosystemBuildsReport {
 
@@ -36,6 +37,8 @@ h4 {margin: 0.2em 0 0 0; margin-right: 3em;}
 
 .addOnVersion {margin-bottom: 0;}
 .scalaIDEVersion {margin-bottom: 0;}
+.scalaIDEVersionDetails {margin-left: 0.5em; margin-bottom: 0; font-size: 80%;}
+.scalaIDEVersionDetails p {margin: 0;}
 
 .notAvailable {color: rgba(0, 0, 0, 0.5); text-shadow: none;}
 .zipped {font-weight: normal; font-style: italic; color: #404040;}
@@ -145,6 +148,14 @@ h4 {margin: 0.2em 0 0 0; margin-right: 3em;}
   def scalaIDEVersionWithAddOns(scalaIDEVersion: ScalaIDEVersion, zipped: Boolean) = {
     <div class="scalaIDEVersion">
       <h3>{ scalaIDEVersion.version }{ if (zipped) <span class="zipped"> zipped</span> }</h3>
+      <div class="scalaIDEVersionDetails">
+      <p>{
+          if (scalaIDEVersion.scalaVersion == UndefinedVersion)
+            "no Scala version"
+          else
+            "on Scala %s".format(scalaIDEVersion.scalaVersion)
+        }</p>
+      </div>
       <div class="usedAddOns">
         <h4>Existing add-ons</h4>
         {

--- a/src/main/scala/org/scalaide/buildtools/ScalaIDEVersion.scala
+++ b/src/main/scala/org/scalaide/buildtools/ScalaIDEVersion.scala
@@ -15,21 +15,37 @@ object ScalaIDEVersion {
             acc + availableAddOn
         }
     }.partition(_._2.repository == siteRepo)
-    
+
+    // the sdt.core bundle
+    val sdtCore = (for {
+      sdtCoreDep <- iu.dependencies.find(_.id == ScalaIDEId)
+      sdtCoreVersion = findStrictVersion(sdtCoreDep.range)
+      sdtCore <- repository.findIU(ScalaIDEId).find(_.version == sdtCoreVersion)
+    } yield sdtCore) match {
+      case Some(iu) =>
+        iu
+      case None =>
+        throw new Exception("failed to find the SDT core bundle for %s".format(iu))
+    }
+
+    // the version of eclipse it depends on
     val eclipseVersion = (for {
-       sdtCoreDep <- iu.dependencies.find(_.id == ScalaIDEId)
-       sdtCoreVersion = findStrictVersion(sdtCoreDep.range)
-       sdtCore <- repository.findIU(ScalaIDEId).find(_.version == sdtCoreVersion)
-       jdtCoreDep <- sdtCore.dependencies.find(_.id == JDTId)
-       eclipseVersion <- EclipseVersion(jdtCoreDep.range)
+      jdtCoreDep <- sdtCore.dependencies.find(_.id == JDTId)
+      eclipseVersion <- EclipseVersion(jdtCoreDep.range)
     } yield eclipseVersion) match {
       case Some(version) =>
         version
       case None =>
         throw new Exception("failed to find the Eclipse version for %s".format(iu))
     }
-    
-    new ScalaIDEVersion(iu, repository, eclipseVersion, associatedExistingAddOns, associatedAvailableAddOns)
+
+    // the version of Scala it depends on
+    val scalaVersion =
+      sdtCore.dependencies.find(_.id == ScalaLibraryId)
+        .map(libDep => findStrictVersion(libDep.range))
+        .getOrElse(throw new Exception("failed to find the Scala version for %s".format(iu)))
+
+    new ScalaIDEVersion(iu, repository, scalaVersion, eclipseVersion, associatedExistingAddOns, associatedAvailableAddOns)
   }
 
   private def latestAssociated(addOns: Map[PluginDescriptor, Seq[AddOn]], version: Version): Map[PluginDescriptor, AddOn] = {
@@ -40,7 +56,7 @@ object ScalaIDEVersion {
   }
 }
 
-case class ScalaIDEVersion private (iu: InstallableUnit, repository: P2Repository, eclipseVersion: EclipseVersion, associatedExistingAddOns: Map[PluginDescriptor, AddOn], associatedAvailableAddOns: Map[PluginDescriptor, AddOn]) {
+case class ScalaIDEVersion private (iu: InstallableUnit, repository: P2Repository, scalaVersion: Version, eclipseVersion: EclipseVersion, associatedExistingAddOns: Map[PluginDescriptor, AddOn], associatedAvailableAddOns: Map[PluginDescriptor, AddOn]) {
 
   def version = iu.version
 


### PR DESCRIPTION
The version is extracted during the creation of ScalaIDEVersion,
and then displayed.

Fixes #4
