### PR TITLE
Stops mergebases from failing if a base is missing

### DIFF
--- a/src/main/scala/org/scalaide/buildtools/MergeBasesBuild.scala
+++ b/src/main/scala/org/scalaide/buildtools/MergeBasesBuild.scala
@@ -15,7 +15,7 @@ object MergeBasesBuild {
     val baseScalaIDEVersions = getScalaIDEVersions(baseRepo)
     val nextBaseScalaIDEVersions = getScalaIDEVersions(nextBaseRepo)
 
-    MergeBasesBuild(ecosystemConf.id, baseRepo, nextBaseRepo, !nextBaseScalaIDEVersions.forall(baseScalaIDEVersions.contains(_)))
+    MergeBasesBuild(ecosystemConf.id, baseRepo, nextBaseRepo, nextBaseRepo.isValid && !nextBaseScalaIDEVersions.forall(baseScalaIDEVersions.contains(_)))
   }
 
   private def getScalaIDEVersions(repo: P2Repository) = repo.findIU(ScalaIDEFeatureIdOsgi).map(_.version)

--- a/src/main/scala/org/scalaide/buildtools/MergeBasesBuildsMavenProjects.scala
+++ b/src/main/scala/org/scalaide/buildtools/MergeBasesBuildsMavenProjects.scala
@@ -70,14 +70,11 @@ object MergeBasesBuildsMavenProjects {
             </executions>
             <configuration>
               <source>
-                <repository>
-                  <url>{ build.baseRepo.location }</url>
-                  <layout>p2</layout>
-                </repository>
-                <repository>
-                  <url>{ build.nextBaseRepo.location }</url>
-                  <layout>p2</layout>
-                </repository>
+                {
+                  if (build.baseRepo.isValid)
+                    repoReference(build.baseRepo)
+                }
+                { repoReference(build.nextBaseRepo) }
               </source>
               <destination>${{project.build.directory}}/base</destination>
             </configuration>
@@ -86,5 +83,11 @@ object MergeBasesBuildsMavenProjects {
       </build>
     </project>
   }
+
+  private def repoReference(repo: P2Repository) =
+    <repository>
+      <url>{ repo.location }</url>
+      <layout>p2</layout>
+    </repository>
 
 }

--- a/src/main/scala/org/scalaide/buildtools/P2Repository.scala
+++ b/src/main/scala/org/scalaide/buildtools/P2Repository.scala
@@ -81,6 +81,7 @@ object InstallableUnit {
 trait P2Repository {
   def uis: Map[String, TreeSet[InstallableUnit]]
   def findIU(unitId: String): TreeSet[InstallableUnit]
+  def isValid: Boolean
   def location: String
 }
 
@@ -89,6 +90,8 @@ case class ValidP2Repository (uis: Map[String, TreeSet[InstallableUnit]], locati
   override def findIU(unitId: String): TreeSet[InstallableUnit] =
     uis get (unitId) getOrElse (TreeSet.empty[InstallableUnit])
 
+  override def isValid = true
+    
   override def toString = "P2Repository(%s)".format(location)
 
   override def equals(o: Any): Boolean = {
@@ -105,6 +108,7 @@ case class ValidP2Repository (uis: Map[String, TreeSet[InstallableUnit]], locati
 case class ErrorP2Repository (errorMessage: String, location: String) extends P2Repository {
   override def findIU(unitId: String): TreeSet[InstallableUnit] = TreeSet()
   override def uis: Map[String, TreeSet[InstallableUnit]] = Map()
+  override def isValid = false
 }
 
 object P2Repository {


### PR DESCRIPTION
Adds a 'isValid' flag in P2Repository.
Do not create a build anymore if next/base is missing.
Do not mirror base anymore if missing.
