### PR TITLE
New --force=<ecosystem-ids> CLI argument to force recreation of ecosystem update-sites

### DIFF
--- a/src/main/scala/org/scalaide/buildtools/EcosystemBuilds.scala
+++ b/src/main/scala/org/scalaide/buildtools/EcosystemBuilds.scala
@@ -4,9 +4,10 @@ object EcosystemBuilds {
 
   import Ecosystem._
 
-  def apply(ecosystemConfs: Seq[EcosystemDescriptor], featureConfs: Seq[PluginDescriptor]): EcosystemBuilds = {
+  def apply(forced: Set[EcosystemId], ecosystemConfs: Seq[EcosystemDescriptor], featureConfs: Seq[PluginDescriptor]): EcosystemBuilds = {
+    def forceEcosystemCreation(conf: EcosystemDescriptor): Boolean = forced contains conf.id  
     val availableAddOns = findAvailableFeatures(featureConfs)
-    new EcosystemBuilds(ecosystemConfs.map(c => EcosystemBuild(c, availableAddOns, featureConfs)), availableAddOns)
+    new EcosystemBuilds(ecosystemConfs.map(c => EcosystemBuild(c, availableAddOns, featureConfs, forceEcosystemCreation(c))), availableAddOns)
   }
 
   def findAvailableFeatures(featureConfs: Seq[PluginDescriptor]): Map[PluginDescriptor, Seq[AddOn]] = {

--- a/src/main/scala/org/scalaide/buildtools/EcosystemBuildsMavenProjects.scala
+++ b/src/main/scala/org/scalaide/buildtools/EcosystemBuildsMavenProjects.scala
@@ -27,7 +27,7 @@ object EcosystemBuildsMavenProjects {
   }
 
   def generateEcosystemProjects(ecosystemBuild: EcosystemBuild, buildFolder: File): Seq[File] = {
-    val ecosystemFolder = new File(buildFolder, ecosystemBuild.id)
+    val ecosystemFolder = new File(buildFolder, ecosystemBuild.id.value)
 
     val siteFolder = if (ecosystemBuild.regenerateEcosystem) {
       generateEcosystemProject(ecosystemBuild.baseScalaIDEVersions, "%s-base".format(ecosystemBuild.id), ecosystemBuild.baseRepo, buildFolder, ecosystemBuild.zippedVersion)

--- a/src/main/scala/org/scalaide/buildtools/EcosystemsDescriptor.scala
+++ b/src/main/scala/org/scalaide/buildtools/EcosystemsDescriptor.scala
@@ -66,4 +66,11 @@ object EcosystemsDescriptor {
   }
 }
 
-final case class EcosystemDescriptor(id: String, site: URL, base: URL, nextSite: URL, nextBase: URL)
+final case class EcosystemDescriptor(id: EcosystemId, site: URL, base: URL, nextSite: URL, nextBase: URL)
+object EcosystemDescriptor {
+  def apply(id: String, site: URL, base: URL, nextSite: URL, nextBase: URL): EcosystemDescriptor = 
+    new EcosystemDescriptor(EcosystemId(id), site, base, nextSite, nextBase)
+}
+case class EcosystemId(value: String) {
+  override def toString = value
+}

--- a/src/main/scala/org/scalaide/buildtools/MergeBasesBuild.scala
+++ b/src/main/scala/org/scalaide/buildtools/MergeBasesBuild.scala
@@ -23,7 +23,7 @@ object MergeBasesBuild {
 }
 
 case class MergeBasesBuild(
-  id: String,
+  id: EcosystemId,
   baseRepo: P2Repository,
   nextBaseRepo: P2Repository,
   toMerge: Boolean)

--- a/src/main/scala/org/scalaide/buildtools/MergeBasesBuildsMavenProjects.scala
+++ b/src/main/scala/org/scalaide/buildtools/MergeBasesBuildsMavenProjects.scala
@@ -24,7 +24,7 @@ object MergeBasesBuildsMavenProjects {
 
   private def generateEcosystemProject(build: MergeBasesBuild, buildFolder: File): Option[File] = {
     if (build.toMerge) {
-      val ecosystemFolder = new File(buildFolder, build.id)
+      val ecosystemFolder = new File(buildFolder, build.id.value)
       ecosystemFolder.mkdirs()
 
       FileUtils.saveXml(new File(ecosystemFolder, "pom.xml"), createEcosystemPomXml(build))


### PR DESCRIPTION
The existing implementation of `EcosystemBuild.shouldBeRegenerated`, which takes care of
deciding if an ecosystem update-site should be recreated, doesn't currently handle the
case where a plug-in is removed from the ecosystem and we would like to recreate the
ecosystem update-site **without** the removed plug-in. The information about what plug-in
was removed wrt the previously built update-site is missing from `ScalaIDEVersion` class.

After discussing the problem with @skyluc, it was decided to implement a hack to override
the behavior of `EcosystemBuild.shouldBeRegenerated` and manually force the recreation of
the update-site via a CLI argument `--force=<comma-separated-list-of-ecosystem-ids>`. The
rationale for this decision is that a proper fix would need some work (not something that
can be quickly put together), and considering that we don't remove plug-ins from the
ecosystem often, we decided it was better to have a workaround than further delay the removal
of InSynth from the ecosystem.

Last but not least, before merging this it would be great if the reviewer could test it, as I've only managed to successfully execute the first step of the ecosystem build (i.e., `mvn -Dmaven.repo.local=${LOCAL_REPO} -Pecosystem-builds exec:java`), but not the following ones (I was getting some weird error message and I don't currently have time to look deeper).
