### PR TITLE
Correctly sort the plugin versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "build-tools"
 
-version := "0.5.1"
+version := "0.5.2-SNAPSHOT"
 
 organization := "org.scala-ide"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.8

--- a/src/main/scala/org/scalaide/buildtools/EcosystemBuilds.scala
+++ b/src/main/scala/org/scalaide/buildtools/EcosystemBuilds.scala
@@ -15,6 +15,7 @@ object EcosystemBuilds {
       f =>
         (f -> f.updateSites.flatMap(r => findAvailableFeatureVersionsFrom(f, Repositories(r))))
     }.toMap
+      .mapValues { _.sortBy{ _.version }.reverse } // the versions have to be ordered from bigger to smaller
   }
 
   def findAvailableFeaturesFrom(featureConfs: Seq[PluginDescriptor], repo: P2Repository): Map[PluginDescriptor, Seq[AddOn]] = {
@@ -27,6 +28,7 @@ object EcosystemBuilds {
             Some((f -> l))
         }
     }.toMap
+      .mapValues { _.sortBy{ _.version }.reverse } // the versions have to be ordered from bigger to smaller
   }
 
   def findAvailableFeatureVersionsFrom(featureConf: PluginDescriptor, repository: P2Repository): Seq[AddOn] = {


### PR DESCRIPTION
The algorithm depend on the fact that the versions of the plugins found
in the different repository are already sorted.
Updated sbt to 0.13.8.